### PR TITLE
fix: rm extra origin

### DIFF
--- a/src/main/java/com/softdevsix/domain/repositories/client/FileManagerClientRepository.java
+++ b/src/main/java/com/softdevsix/domain/repositories/client/FileManagerClientRepository.java
@@ -29,7 +29,7 @@ public class FileManagerClientRepository implements IFileManagerClientRepository
     public FileManagerClientRepository(RestTemplate restTemplate,
                                        @Value("${file.manager.base-url}") String baseUrl) {
         this.restTemplate = restTemplate;
-        this.baseUrl = baseUrl;
+        this.baseUrl = String.format("%s/fileManager", baseUrl);
     }
 
     @Override

--- a/src/main/java/com/softdevsix/infrastructure/configuration/cors/CustomCorsConfiguration.java
+++ b/src/main/java/com/softdevsix/infrastructure/configuration/cors/CustomCorsConfiguration.java
@@ -12,7 +12,7 @@ public class CustomCorsConfiguration implements CorsConfigurationSource {
     @Override
     public CorsConfiguration getCorsConfiguration(HttpServletRequest request) {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of(System.getenv("ArgosUI_address"), System.getenv("ArgosFileManager_address")));
+        config.setAllowedOrigins(List.of(System.getenv("ARGOS_UI_ADDRESS")));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE"));
         config.setAllowedHeaders(List.of("*"));
         return config;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,4 +10,4 @@ spring:
 
 file:
   manager:
-    base-url: http://localhost:8080/fileManager
+    base-url: ${ARGOS_FILE_MANAGER_API_ADDRESS:http://localhost:8080}

--- a/src/test/java/com/softdevsix/domain/repositories/client/FileManagerClientRepositoryTest.java
+++ b/src/test/java/com/softdevsix/domain/repositories/client/FileManagerClientRepositoryTest.java
@@ -22,9 +22,10 @@ class FileManagerClientRepositoryTest {
     void testGetCoverageJson() {
         RestTemplate restTemplate = Mockito.mock(RestTemplate.class);
 
-        String baseUrl = "http://localhost:8080/fileManager";
+        String baseUrl = "http://localhost:8080";
 
         IFileManagerClientRepository fileManager = new FileManagerClientRepository(restTemplate, baseUrl);
+        baseUrl += "/fileManager";
 
         String projectId = "6570409c-44d0-4ca5-b271-fe433a0a290a";
 


### PR DESCRIPTION
<!-- Provide a general summary of the pull request in the Title above -->
<!-- Please complete this template before creating the pull request. -->

## Related Tickets & US
fixes: #49

## Description
<!-- Please include a summary of your changes. -->
<!-- Also include relevant motivation and context. List any dependencies that are required for this. -->

fix: use env vars instead of localhost

ArgosApi is configured with localhost values which have an impact when
trying to dockerize.

- replaced localhost mentions with env vars like FILE_MANAGER_API

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

1. Run argos-ui `./gradlew run`
2. Run argos-filemanager either develop or production mode
3. Run argos-ui production *docker image*
4. By using the UI attempt to upload a project

New env variables
```
ARGOS_FILE_MANAGER_API_ADDRESS=http://prod-argos.westus2.cloudapp.azure.com:8080
ARGOS_UI_ADDRESS=http://prod-argos.westus2.cloudapp.azure.com:5173
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/SoftDevSix/ArgosApplication/50)
<!-- Reviewable:end -->
